### PR TITLE
consider the xtradb_bind_interface for master default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ xtradb_wsrep_cluster_address: "gcomm://{{ groups[xtradb_nodes_group] | map('extr
 
 # Defines the which node should be considered the master in the cluster
 # Used to bootstrap cluster
-xtradb_master_node: "{{ hostvars[ groups[xtradb_nodes_group][0] ].ansible_default_ipv4.address }}"
+xtradb_master_node: "{{ hostvars[ groups[xtradb_nodes_group][0] ]['ansible_' ~ xtradb_bind_interface].ipv4.address }}"
 
 # Defines the version
 xtradb_version: "57"


### PR DESCRIPTION
When building the default value of `xtradb_master_node`, the ip chosen
should be the one on the `xtradb_bind_interface`, otherwise
`xtradb_bind_address` will never match `xtradb_master_node`, thus the
bootstrap and the postscripts are never run.